### PR TITLE
Add support for handling ping responses on long op's

### DIFF
--- a/pyownet/protocol.py
+++ b/pyownet/protocol.py
@@ -297,8 +297,15 @@ class OwnetConnection(object):
         tohead = _ToServerHeader(payload=len(payload), type=type, flags=flags, 
             size=size, offset=offset)
         self._send_msg(tohead, payload)
-        fromhead, data = self._read_msg()
-        return fromhead.ret, fromhead.flags, data
+        while True:
+            fromhead, data = self._read_msg()
+
+            if fromhead.payload < 0 and type != MSG_NOP:
+                # Server said PING to keep connection alive during
+                # lenghty op
+                continue
+
+            return fromhead.ret, fromhead.flags, data
 
     def _send_msg(self, header, payload):
         "send message to server"


### PR DESCRIPTION
When owserver is busy (i.e. high load/contention, or long ops), it will
send ping frames every second or so.

How to reproduce:
1. Run pyownet, with verbose, and repeatedly read a temperature sensor (/uncached/nnnn/temperature).
2. Run separate console which does while true; do owread /uncached/nnnn/temperature; done

(or just two pyownet I guess). You will eventually notice that it receives packages with -1 payload.
